### PR TITLE
Add content type header

### DIFF
--- a/auth/api.py
+++ b/auth/api.py
@@ -174,6 +174,7 @@ def export(body: SurveyParticipantModel):
     """
     requests.post(
         f"http://{config['GDRIVE_APP_HOST']}:{config['GDRIVE_APP_PORT']}/survey-export",
+        headers={"Content-Type": "application/json"},
         json=body.json(),
         timeout=5,
     )


### PR DESCRIPTION
GDrive microservice is throwing a `422 unprocessable entity` error. Request to GDrive is missing content type header.