### PR TITLE
Serialize request body to a dict

### DIFF
--- a/auth/api.py
+++ b/auth/api.py
@@ -1,6 +1,5 @@
 # server/auth/views.py
 import requests
-import json
 import flask_pydantic
 
 from flask import Blueprint, request, make_response, jsonify

--- a/auth/api.py
+++ b/auth/api.py
@@ -1,7 +1,8 @@
 # server/auth/views.py
 import requests
-
+import json
 import flask_pydantic
+
 from flask import Blueprint, request, make_response, jsonify
 from pydantic import BaseModel
 from flask_httpauth import HTTPTokenAuth
@@ -172,10 +173,14 @@ def export(body: SurveyParticipantModel):
     """
     GDrive microservice interface
     """
+
+    json_body_string = body.json()
+    json_body_dict = json.loads(json_body_string)
+
     requests.post(
         f"http://{config['GDRIVE_APP_HOST']}:{config['GDRIVE_APP_PORT']}/survey-export",
         headers={"Content-Type": "application/json"},
-        json=body.json(),
+        json=json_body_dict,
         timeout=5,
     )
     return "Response ID successfully posted", 200

--- a/auth/api.py
+++ b/auth/api.py
@@ -174,13 +174,9 @@ def export(body: SurveyParticipantModel):
     GDrive microservice interface
     """
 
-    json_body_string = body.json()
-    json_body_dict = json.loads(json_body_string)
-
     requests.post(
         f"http://{config['GDRIVE_APP_HOST']}:{config['GDRIVE_APP_PORT']}/survey-export",
-        headers={"Content-Type": "application/json"},
-        json=json_body_dict,
+        data=body.json(),
         timeout=5,
     )
     return "Response ID successfully posted", 200


### PR DESCRIPTION
<del>Pydantic doesn't support a straightforward method for converting a model to a dict, needed to use the json library to do so. The requests library supports sending a string as a request body, which it was doing, but it needed to send a dict. The GDrive microservice was trying to convert a string to a pydantic model. These python libraries are starting to become bloatware.</del>

Use `data` instead of `json` to pass json string.