### PR TITLE
Default participant to None

### DIFF
--- a/auth/api.py
+++ b/auth/api.py
@@ -168,7 +168,7 @@ class SurveyParticipantModel(BaseModel):
 
     surveyId: str
     responseId: str
-    participant: Optional[ParticipantModel]
+    participant: Optional[ParticipantModel] = None
 
 
 @gdrive_blueprint.route("/survey-response", methods=["POST"])


### PR DESCRIPTION
Type Optional will still require something to be present. Participant must be defaulted to None if nothing is present to avoid an error.